### PR TITLE
fix : User 엔티티 현재 주소 매핑 오류 수정 #5

### DIFF
--- a/src/main/java/com/sparta/oneeat/user/entity/User.java
+++ b/src/main/java/com/sparta/oneeat/user/entity/User.java
@@ -18,11 +18,15 @@ public class User {
     @Column(name = "USERS_ID", nullable = false)
     private Long id;
 
+
+    @OneToOne
+    @JoinColumn(name="USER_ADDRESS_ID", nullable = false)
+    private UserAddress currentAddress;
+
     @OneToMany(mappedBy = "user")
     private List<Store> storeList;
 
     @OneToMany(mappedBy = "user")
-    @JoinColumn(name="USER_ADDRESS_ID", nullable = false)
     private List<UserAddress> userAddress;
 
     @Column(name="USERS_USERNAME", nullable = false)


### PR DESCRIPTION
## 📎 이슈번호 
> #5

## 📎 어떤 이유로 PR를 하셨나요?
> Application Context 시작시 발생하는 오류를 해결하기 위해 PR을 생성했습니다.

## 📎 작업 사항
> User 엔티티의 @JoinColumn과 @mappedBy 충돌 문제를 해결했습니다.
> User 엔티티의 userAddress와 currentAddress 컬럼을 분리했습니다.

## 📎 참고 사항
> 
