### PR TITLE
feat : 주문 목록 조회 #7

### DIFF
--- a/src/main/java/com/sparta/oneeat/order/Service/OrderService.java
+++ b/src/main/java/com/sparta/oneeat/order/Service/OrderService.java
@@ -1,0 +1,10 @@
+package com.sparta.oneeat.order.Service;
+
+import com.sparta.oneeat.order.dto.OrderListDto;
+import org.springframework.data.domain.Page;
+
+public interface OrderService {
+
+    // 주문 리스트 조회
+    Page<OrderListDto> getOrderList(long userId, int page, int size, String sort, boolean isAsc);
+}

--- a/src/main/java/com/sparta/oneeat/order/Service/OrderServiceImpl.java
+++ b/src/main/java/com/sparta/oneeat/order/Service/OrderServiceImpl.java
@@ -1,0 +1,56 @@
+package com.sparta.oneeat.order.Service;
+
+import com.sparta.oneeat.common.exception.CustomException;
+import com.sparta.oneeat.common.exception.ExceptionType;
+import com.sparta.oneeat.order.dto.OrderListDto;
+import com.sparta.oneeat.order.entity.Order;
+import com.sparta.oneeat.order.repository.OrderRepository;
+import com.sparta.oneeat.store.entity.Store;
+import com.sparta.oneeat.store.repository.StoreRepository;
+import com.sparta.oneeat.user.entity.User;
+import com.sparta.oneeat.user.entity.UserRoleEnum;
+import com.sparta.oneeat.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OrderServiceImpl implements OrderService{
+
+    private final OrderRepository orderRepository;
+    private final UserRepository userRepository;
+    private final StoreRepository storeRepository;
+
+    @Override
+    public Page<OrderListDto> getOrderList(long userId, int page, int size, String sort, boolean isAsc) {
+        Sort.Direction direction = isAsc ? Sort.Direction.ASC : Sort.Direction.DESC;
+        Sort sort1 = Sort.by(direction, sort);
+        Pageable pageable = PageRequest.of(page, size, sort1);
+
+        // 유저 권한 확인
+        User user = userRepository.findById(userId).orElseThrow(() -> new CustomException(ExceptionType.INTERNAL_SERVER_ERROR));
+        UserRoleEnum userRole = user.getRole();
+
+        Page<Order> orderList = null;
+
+        if(userRole == UserRoleEnum.CUSTOMER){
+            // 고객일 경우 해당 고객의 주문 리스트 조회
+            orderList = orderRepository.findAllByUser(user, pageable);
+        }else if(userRole == UserRoleEnum.OWNER){
+            // 가게 주인일 경우 해당 가게의 주문 리스트 조회
+            Store store = storeRepository.findByUser(user).orElseThrow(() -> new CustomException(ExceptionType.INTERNAL_SERVER_ERROR));
+            orderList = orderRepository.findAllByStore(store, pageable);
+        }
+        
+        return orderList.map(OrderListDto::new);
+    }
+
+}

--- a/src/main/java/com/sparta/oneeat/order/controller/OrderController.java
+++ b/src/main/java/com/sparta/oneeat/order/controller/OrderController.java
@@ -1,0 +1,48 @@
+package com.sparta.oneeat.order.controller;
+
+import com.sparta.oneeat.common.response.BaseResponseBody;
+import com.sparta.oneeat.order.Service.OrderService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/order")
+@RequiredArgsConstructor
+@Tag(name="Order", description="Order API")
+public class OrderController {
+
+    private final OrderService orderService;
+
+    @Operation(summary = "주문 목록 조회", description = "자신의 주문 리스트를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "주문 목록 조회 성공"),
+            @ApiResponse(responseCode = "500", description = "주문 목록 조회 실패")
+    })
+    @GetMapping("")
+    public ResponseEntity<? extends BaseResponseBody> getOrderList(
+//            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @RequestParam("page") int page,
+            @RequestParam("size") int size,
+            @RequestParam("sort") String sort,
+            @RequestParam("isAsc") boolean isAsc
+    ){
+
+        log.info("page : {}", page);
+        log.info("size : {}", size);
+        log.info("sort : {}", sort);
+        log.info("isAsc : {}", isAsc);
+
+        return ResponseEntity.status(200).body(BaseResponseBody.of(0, orderService.getOrderList(2L, (page-1), size, sort, isAsc)));
+    }
+
+
+}
+
+

--- a/src/main/java/com/sparta/oneeat/order/dto/OrderListDto.java
+++ b/src/main/java/com/sparta/oneeat/order/dto/OrderListDto.java
@@ -1,0 +1,29 @@
+package com.sparta.oneeat.order.dto;
+
+import com.sparta.oneeat.order.entity.Order;
+import com.sparta.oneeat.order.entity.OrderStatusEnum;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class OrderListDto {
+    private UUID orderId;
+    private String storeName;
+    private int totalPrice;
+    private OrderStatusEnum status;
+    private LocalDateTime orderDate;
+
+    public OrderListDto(Order order){
+        this.orderId = order.getId();
+        this.storeName = order.getStore().getName();
+        this.totalPrice = order.getTotalPrice();
+        this.status = order.getStatus();
+        this.orderDate = order.getCreatedAt();
+    }
+}

--- a/src/main/java/com/sparta/oneeat/order/entity/Order.java
+++ b/src/main/java/com/sparta/oneeat/order/entity/Order.java
@@ -1,5 +1,6 @@
 package com.sparta.oneeat.order.entity;
 
+import com.sparta.oneeat.common.entity.BaseEntity;
 import com.sparta.oneeat.store.entity.Store;
 import com.sparta.oneeat.user.entity.User;
 import jakarta.persistence.*;
@@ -14,24 +15,24 @@ import java.util.UUID;
 @Table(name = "P_ORDER")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Order {
+public class Order extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     @Column(name="ORDER_ID", nullable = false)
     private UUID id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "USERS_ID")
     private User user;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "STORE_ID")
     private Store store;
 
-    @OneToOne(mappedBy = "order")
+    @OneToOne(mappedBy = "order", fetch = FetchType.LAZY)
     private Payment payment;
 
-    @OneToMany(mappedBy = "order")
+    @OneToMany(mappedBy = "order", fetch = FetchType.LAZY)
     private List<OrderMenu> orderMenuList;
 
     @Column(name = "ORDER_TYPE", nullable = false)

--- a/src/main/java/com/sparta/oneeat/order/entity/OrderStatusEnum.java
+++ b/src/main/java/com/sparta/oneeat/order/entity/OrderStatusEnum.java
@@ -1,4 +1,11 @@
 package com.sparta.oneeat.order.entity;
 
 public enum OrderStatusEnum {
+    PAYMENT_PENDING,       // 결제 대기
+    PAYMENT_APPROVED,      // 결제 승인
+    PAYMENT_REJECTED,      // 결제 거절
+    PAYMENT_CANCELLED,     // 결제 취소
+    COOKING,               // 요리중
+    DELIVERING,            // 배달중
+    DELIVERY_COMPLETED     // 배달완료
 }

--- a/src/main/java/com/sparta/oneeat/order/entity/OrderTypeEnum.java
+++ b/src/main/java/com/sparta/oneeat/order/entity/OrderTypeEnum.java
@@ -1,4 +1,6 @@
 package com.sparta.oneeat.order.entity;
 
 public enum OrderTypeEnum {
+    ONLINE, // 온라인
+    ONSITE  // 대면
 }

--- a/src/main/java/com/sparta/oneeat/order/repository/OrderRepository.java
+++ b/src/main/java/com/sparta/oneeat/order/repository/OrderRepository.java
@@ -1,0 +1,19 @@
+package com.sparta.oneeat.order.repository;
+
+import com.sparta.oneeat.order.entity.Order;
+import com.sparta.oneeat.store.entity.Store;
+import com.sparta.oneeat.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface OrderRepository extends JpaRepository<Order, UUID> {
+
+    // 유저 주문 리스트 조회
+    Page<Order> findAllByUser(User user, Pageable pageable);
+
+    // 가게 주문 리스트 조회
+    Page<Order> findAllByStore(Store store, Pageable pageable);
+}

--- a/src/main/java/com/sparta/oneeat/store/repository/StoreRepository.java
+++ b/src/main/java/com/sparta/oneeat/store/repository/StoreRepository.java
@@ -1,0 +1,13 @@
+package com.sparta.oneeat.store.repository;
+
+import com.sparta.oneeat.store.entity.Store;
+import com.sparta.oneeat.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface StoreRepository extends JpaRepository<Store, UUID> {
+    // 지정된 유저와 연관된 가게 조회
+    Optional<Store> findByUser(User user);
+}

--- a/src/main/java/com/sparta/oneeat/user/repository/UserRepository.java
+++ b/src/main/java/com/sparta/oneeat/user/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package com.sparta.oneeat.user.repository;
+
+import com.sparta.oneeat.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1gmT7PM8Ae7qJ9pZ8ehH0KMK8zonBFI%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=vRKbnK6)
## 📎 이슈번호 
> #7 

## 📎 어떤 이유로 PR를 하셨나요?
> 주문 목록 조회 API 기능 구현

## 📎 작업 사항
> Order 엔티티 수정  (BaseEntity 상속 및 지연 로딩 처리)
> 유저, 가게 데이터 조회를 위한 리포지토리 생성
> 주문 목록 조회 API 기능 구현

## 📎 참고 사항
> 현재 파라미터로 userId 값 자체를 전달하고 있는데 인증 기능 구현되면 `@AuthenticationPrincipal`로 수정할 예정
> User, Store 엔티티가 존재하지 않을 때 현재 `INTERNAL_SERVER_ERROR`로 예외처리 하는데 추후 상세한 예외 추가 필요
