### PR TITLE
fix : 로그인 DTO 바인딩 오류 수정 #24

### DIFF
--- a/src/main/java/com/sparta/oneeat/auth/dto/LoginRequestDto.java
+++ b/src/main/java/com/sparta/oneeat/auth/dto/LoginRequestDto.java
@@ -4,6 +4,7 @@ import lombok.*;
 
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor
 public class LoginRequestDto {
     private String username;
     private String password;


### PR DESCRIPTION
## 📎 이슈번호 
> #24

## 📎 어떤 이유로 PR를 하셨나요?
> 로그인 API 요청시 DTO 바인딩 실패로 인한 500 에러를 해결했습니다.

## 📎 작업 사항
> 요청 DTO 객체에 기본 생성자 어노테이션을 추가했습니다.

## 📎 참고 사항
> 
