### PR TITLE
refactor : 유저, 주소 도메인 숨김 제외 처리

### DIFF
--- a/src/main/java/com/sparta/oneeat/auth/service/UserDetailsServiceImpl.java
+++ b/src/main/java/com/sparta/oneeat/auth/service/UserDetailsServiceImpl.java
@@ -18,7 +18,7 @@ public class UserDetailsServiceImpl implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        User user = userRepository.findByName(username)
+        User user = userRepository.findByNameAndDeletedAtIsNull(username)
                 .orElseThrow(() -> new UsernameNotFoundException("Not Found " + username));
 
         return new UserDetailsImpl(user);

--- a/src/main/java/com/sparta/oneeat/user/repository/UserAddressRepository.java
+++ b/src/main/java/com/sparta/oneeat/user/repository/UserAddressRepository.java
@@ -12,7 +12,7 @@ import java.util.UUID;
 public interface UserAddressRepository extends JpaRepository<UserAddress, UUID> {
     Optional<UserAddress> findByUserIdAndAddress(Long id, String address);
 
-    List<UserAddress> findByUserId(Long id);
+    List<UserAddress> findByUserIdAndDeletedAtIsNull(Long id);
 
-    Optional<UserAddress> findByIdAndUserId(UUID id, Long userId);
+    Optional<UserAddress> findByIdAndUserIdAndDeletedAtIsNull(UUID id, Long userId);
 }

--- a/src/main/java/com/sparta/oneeat/user/repository/UserRepository.java
+++ b/src/main/java/com/sparta/oneeat/user/repository/UserRepository.java
@@ -12,6 +12,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByName(String username);
 
+    Optional<User> findByNameAndDeletedAtIsNull(String username);
+
     Optional<User> findByNickname(String nickname);
 
     Optional<Object> findByEmail(String email);

--- a/src/main/java/com/sparta/oneeat/user/service/UserAddressServiceImpl.java
+++ b/src/main/java/com/sparta/oneeat/user/service/UserAddressServiceImpl.java
@@ -46,7 +46,7 @@ public class UserAddressServiceImpl implements UserAddressService {
 
         this.validateUserExist(userId);
 
-        List<UserAddress> userAddressList = userAddressRepository.findByUserId(userId);
+        List<UserAddress> userAddressList = userAddressRepository.findByUserIdAndDeletedAtIsNull(userId);
         if (userAddressList.isEmpty()) {
             log.warn("회원의 주소록에 주소가 존재하지 않습니다.");
             throw new CustomException(ExceptionType.USER_NOT_EXIST_ADDRESS);
@@ -122,7 +122,7 @@ public class UserAddressServiceImpl implements UserAddressService {
     }
 
     protected UserAddress validateAddressExist(Long userId, UUID addressId) {
-        UserAddress userAddress = userAddressRepository.findByIdAndUserId(addressId, userId).orElseThrow(() ->
+        UserAddress userAddress = userAddressRepository.findByIdAndUserIdAndDeletedAtIsNull(addressId, userId).orElseThrow(() ->
                 new CustomException(ExceptionType.USER_NOT_EXIST_ADDRESS)
         );
         log.info("회원의 주소록에 주소가 존재합니다. Address: {}", userAddress.getAddress());


### PR DESCRIPTION
## 📎 이슈번호 
> #72

## 📎 어떤 이유로 PR를 하셨나요?
> 비활성화 데이터 로직 누락을 수정했습니다.

## 📎 작업 사항
> 변경이 필요한 유저 및 주소의 API에 비활성화 제외 로직으로 수정했습니다. 

## 📎 참고 사항
> 
