### PR TITLE
fix : 주문생성 시 해당 가게의 메뉴가 아니더라도 생성되는 에러 처리 #82

### DIFF
--- a/src/main/java/com/sparta/oneeat/common/exception/ExceptionType.java
+++ b/src/main/java/com/sparta/oneeat/common/exception/ExceptionType.java
@@ -38,6 +38,7 @@ public enum ExceptionType {
     MODIFY_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "O-006", "상태 수정이 가능한 주문이 아닙니다."),
     PRICE_MISMATCH(HttpStatus.BAD_REQUEST, "O-007", "메뉴 가격이 일치하지 않습니다."),
     TOTAL_PRICE_MISMATCH(HttpStatus.BAD_REQUEST, "O-008", "총 가격이 일치하지 않습니다."),
+    INVALID_MENU_ORDER(HttpStatus.BAD_REQUEST, "O-009", "해당 가게의 메뉴가 아닙니다."),
 
     // 리뷰
     REVIEW_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "R-001", "해당 주문의 리뷰가 존재합니다"),

--- a/src/main/java/com/sparta/oneeat/order/Service/OrderServiceImpl.java
+++ b/src/main/java/com/sparta/oneeat/order/Service/OrderServiceImpl.java
@@ -174,6 +174,10 @@ public class OrderServiceImpl implements OrderService{
         // 메뉴 돌아가면서 주문 정보 테이블 넣어주기
         for(CreateOrderReqDto.MenuDto menuDto : createOrderReqDto.getMenuList()){
             Menu menu = menuRepository.findById(menuDto.getMenuId()).orElseThrow(() -> new CustomException(ExceptionType.INTERNAL_SERVER_ERROR));
+
+            // 해당 메뉴의 가게인지 확인
+            if(!Objects.equals(menu.getStore().getId(), store.getId())) throw new CustomException(ExceptionType.INVALID_MENU_ORDER);
+
             log.info("요청 메뉴 가격 : {}", menuDto.getPrice());
             log.info("DB 메뉴 가격 : {}", menu.getPrice());
 


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1eECYYMScTDVauPoRIfFBqjRPxd1tKnM%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=2O2Jwy5)
## 📎 이슈번호 
> #82 

## 📎 어떤 이유로 PR를 하셨나요?
> 주문 생성 API에서 잘못된 가게 메뉴가 입력되어도 생성되는 버그 처리

## 📎 작업 사항
> 메뉴와 가게 정보가 일치하는지 확인 후 일치하지 않으면 에러 반환 
<img width="485" alt="image" src="https://github.com/user-attachments/assets/ebfe6242-2bd5-4a65-ab02-dea872321410">


## 📎 참고 사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
