### PR TITLE
fix : 잘못된 변수가 적용된 닉네임 중복검사 수정 #86

### DIFF
--- a/src/main/java/com/sparta/oneeat/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/sparta/oneeat/auth/service/AuthServiceImpl.java
@@ -31,7 +31,7 @@ public class AuthServiceImpl implements AuthService {
             throw new CustomException(ExceptionType.USER_EXIST_USERNAME);
         }
 
-        if (userRepository.findByNickname(username).isPresent()) {
+        if (userRepository.findByNickname(nickname).isPresent()) {
             log.warn("중복된 닉네임 입니다: {}", nickname);
             throw new CustomException(ExceptionType.USER_EXIST_NICKNAME);
         }


### PR DESCRIPTION
## 📎 이슈번호 
> #86

## 📎 어떤 이유로 PR를 하셨나요?
> 잘못된 변수가 적용되어 닉네임 중복검사가 제대로 작동되지 않는 것을 수정했습니다.

## 📎 작업 사항
> 변수를 올바르게 전달하도록 수정했습니다.

## 📎 참고 사항
> 
