### PR TITLE
fix : 숨김 설정된 가게 카테고리가 조회 결과에 포함되는 문제 수정 #92

### DIFF
--- a/src/main/java/com/sparta/oneeat/category/repository/StoreCategotyRepository.java
+++ b/src/main/java/com/sparta/oneeat/category/repository/StoreCategotyRepository.java
@@ -1,6 +1,8 @@
 package com.sparta.oneeat.category.repository;
 
 import com.sparta.oneeat.category.entity.Category;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -8,4 +10,6 @@ import java.util.UUID;
 
 public interface StoreCategotyRepository extends JpaRepository<Category, UUID> {
     Optional<Category> findByCategoryName(String category);
+
+    Page<Category> findAllByDeletedAtIsNull(Pageable pageable);
 }

--- a/src/main/java/com/sparta/oneeat/category/service/StoreCategoryServiceImpl.java
+++ b/src/main/java/com/sparta/oneeat/category/service/StoreCategoryServiceImpl.java
@@ -103,7 +103,7 @@ public class StoreCategoryServiceImpl implements StoreCategoryService{
         Sort sort1 = Sort.by(direction, sort);
         Pageable pageable = PageRequest.of(page, size, sort1);
 
-        Page<Category> categories = storeCategotyRepository.findAll(pageable);
+        Page<Category> categories = storeCategotyRepository.findAllByDeletedAtIsNull(pageable);
 
         return categories.map(CategoryListResDto::new);
     }


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1MqNOcCCFM6CDXk3PtA2DqwVUhTORvL7I%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=9WrjW3E)
## 📎 이슈번호 
> #92 

## 📎 어떤 이유로 PR를 하셨나요?
> 숨김 설정된 가게 카테고리가 조회 결과에 포함되는 문제 수정

## 📎 작업 사항
> 조회 메서드 `finaAll()` -> `findAllByDeletedAtIsNull()` 메서드 변경

## 📎 참고 사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
