### PR TITLE
Fix/ 메뉴 조회 매핑 메서드 수정

### DIFF
--- a/src/main/java/com/sparta/oneeat/menu/controller/MenuController.java
+++ b/src/main/java/com/sparta/oneeat/menu/controller/MenuController.java
@@ -98,7 +98,7 @@ public class MenuController {
         @RequestParam(defaultValue = "price") String sort) {
 
         return ResponseEntity.status(200)
-            .body(BaseResponseBody.of(0, menuService.getMenuList(userDetails.getUser(), storeId, page, size, sort)));
+            .body(BaseResponseBody.of(0, menuService.getMenuList(storeId, page, size, sort)));
     }
 
     @Operation(summary = "메뉴 수정", description = "메뉴를 수정합니다")

--- a/src/main/java/com/sparta/oneeat/menu/controller/MenuController.java
+++ b/src/main/java/com/sparta/oneeat/menu/controller/MenuController.java
@@ -74,7 +74,7 @@ public class MenuController {
         @ApiResponse(responseCode = "200", description = "메뉴 조회 성공"),
         @ApiResponse(responseCode = "500", description = "메뉴 조회 실패")
     })
-    @PostMapping("/store/{storeId}/menu/{menuId}")
+    @GetMapping("/store/{storeId}/menu/{menuId}")
     public ResponseEntity<? extends BaseResponseBody> getMenuDetail(
         @AuthenticationPrincipal UserDetailsImpl userDetails,
         @PathVariable UUID storeId,

--- a/src/main/java/com/sparta/oneeat/menu/service/MenuService.java
+++ b/src/main/java/com/sparta/oneeat/menu/service/MenuService.java
@@ -84,14 +84,14 @@ public class MenuService {
     }
 
     // 가게의 모든 메뉴를 조회 (가격 내림)
-
-    public Page<MenuResponseDto> getMenuList(User user, UUID storeId, int page, int size,
+    public Page<MenuResponseDto> getMenuList(UUID storeId, int page, int size,
         String sort) {
 
         Pageable pageable = PageRequest.of(page, size, Sort.by(Direction.DESC, sort));
 
-        // 가게 검증 / 사장이라면 해당 유저에게 해당 가게가 있는지
-        Store store = validateStore(user, storeId);
+        // 가게 검증
+        Store store = storeRepository.findById(storeId)
+            .orElseThrow(() -> new CustomException(ExceptionType.INTERNAL_SERVER_ERROR)); // 가게 없음
 
         // 정렬 조건에 맞게 해당 가게의 메뉴 전체를 가져온다
         Page<Menu> menus = menuRepository.findAllByStoreAndDeletedAtIsNull(store, pageable);


### PR DESCRIPTION
## 📎 이슈번호 
> #95 #96 

## 📎 어떤 이유로 PR를 하셨나요?
> 1. 메뉴 조회 시 Get이 아닌 Post로 매핑 메서드 작성되어 있어 수정했습니다.
> 2. 사장이 메뉴 목록을 조회할 때 해당 가게가 본인의 가게가 아니어도 메뉴 전체 리스트를 확인할 수 있어야 하는데 특정 가게가 해당 유저의 가게가 맞는지에 대한 불필요한 검증으로 인해 예외가 발생하여 가게 존재 여부만 검증하도록 수정했습니다

## 📎 작업 사항
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

## 📎 참고 사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
