### PR TITLE
fix : 잘못 변경된 key 경로 값 수정 #104

### DIFF
--- a/src/main/java/com/sparta/oneeat/common/util/JwtUtil.java
+++ b/src/main/java/com/sparta/oneeat/common/util/JwtUtil.java
@@ -24,7 +24,7 @@ public class JwtUtil {
     private final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256;
     private Key key;
 
-    @Value("${JWT_SECRET_KEY}")
+    @Value("${jwt.secret_key}")
     private String secretKey;
 
     @PostConstruct

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,7 +19,7 @@ spring:
         jdbc:
           time_zone: Asia/Seoul
 jwt:
-  secret_key: ${SECRET_KEY}
+  secret_key: ${JWT_SECRET_KEY}
 
 api:
   key: ${API_KEY}


### PR DESCRIPTION
## 📎 이슈번호 
> #104

## 📎 어떤 이유로 PR를 하셨나요?
> 키를 인식하지 못해 발생하는 에러를 수정했습니다.

## 📎 작업 사항
> 시크릿 키 값 변경시에 잘못 변경된 경로를 올바른 경로로 수정
> 원래 의도대로 키값을 대문자화 했습니다.

## 📎 참고 사항
> 